### PR TITLE
Add prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This tool requires nodejs 16 or better and yarn as well as react-scripts and typ
 `sudo apt update && sudo apt install -y curl` and then `curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -` and finally `sudo apt install -y nodejs`.
 
 Once nodejs and npm have been installed, install yarn: `sudo corepack enable` and test it's there with `yarn --version`
-> If this fails, install yarn via npm instead: `sudo npm install --global yarn`
+> Alternatively you can [install yarn and let it pull in nodejs](https://linuxize.com/post/how-to-install-yarn-on-ubuntu-20-04/); instead of installing nodejs and relying on its yarn.
 
 Install react-scripts and typescript: `yarn add react-scripts typescript`
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ This is a simple react app to manage your ETH2 validator keystores. It allows to
 
 [See more screenshots](images)
 
+## Prerequisites
+
+This tool requires nodejs 16 or better and yarn as well as react-scripts and typescript. Installation of nodejs and npm differs by OS, for Ubuntu 20.04: 
+
+`sudo apt update && sudo apt install -y curl` and then `curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -` and finally `sudo apt install -y nodejs`.
+
+Once nodejs and npm have been installed, install yarn: `sudo corepack enable` and test it's there with `yarn --version`
+> If this fails, install yarn via npm instead: `sudo npm install --global yarn`
+
+Install react-scripts and typescript: `yarn add react-scripts typescript`
+
 ## Running
 
 Requires a running signer instance like a ETH2 validator client or a [web3signer](https://github.com/ConsenSys/web3signer) instance.


### PR DESCRIPTION
The yarn installation was a little yanky on my system. Corepack brought `/usr/bin/yarn` in but then complained it couldn't find `/usr/local/bin/yarn`. Installing via npm worked.